### PR TITLE
$(window) returns window instance, not array containing window instance

### DIFF
--- a/ender.js
+++ b/ender.js
@@ -15,7 +15,9 @@
 
   function boosh(s, r) {
     var els;
-    if (ender._select && typeof s == 'string' || s.nodeName || s.length && 'item' in s) { //string || node || nodelist
+    if (s == window) {
+      els = [s];
+    } else if (ender._select && typeof s == 'string' || s.nodeName || s.length && 'item' in s) { //string || node || nodelist
       els = ender._select(s, r);
       els.selector = s;
     } else {


### PR DESCRIPTION
The window object has a length property which returns the number of frames in the window (https://developer.mozilla.org/en/DOM/window).  In the boosh function, if the selector is not a string, node or nodelist, its length property is checked.  If the length property is finite, the selector is returned, otherwise it is wrapped in an array.  Returning the window object breaks the ability to bind events to it, such as resize.  To fix this issue, I've checked the selector type to determine if it is a window and then return the window object in an array.
