### PR TITLE
for npm modules that assume `global` is the global object

### DIFF
--- a/ender.js
+++ b/ender.js
@@ -6,6 +6,11 @@
   */
 !function (context) {
 
+  // a global object for node.js module compatiblity
+  // ============================================
+
+  context['global'] = context;
+
   // Implements simple module system
   // losely based on CommonJS Modules spec v1.1.1
   // ============================================


### PR DESCRIPTION
I suppose that good little modules should use something like this:

```
(function (context, undefined) {
    "use strict";

    // blah blah
}(this));
```

but since many already assume "global" it might be nice to have that.

Thoughts?
