### PR TITLE
discourage the use of the ender global and require it instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,21 @@ The bridge is what Ender uses to connect modules to the main ender object.
 
 It's key to note that Ender users have the optional ability to call <code>noConflict()</code> on Ender in case the top-level <code>$</code> symbol is already taken. With that in mind, Developers should always wrap their Ender extensions as such:
 
-    !function ($) {
+    !function () {
+      var $ = require('ender');
       // extend ender
-    }(ender);
+    }();
 
 <h3>Top level methods</h3>
 
 To create top level methods, like for example <code>$.myUtility(...)</code>, you can hook into Ender by calling the ender method:
 
-    !function ($) {
+    !function () {
+      var $ = require('ender');
       $.ender({
         myUtility: myLibFn
       });
-    }(ender);
+    }();
 
 (*note - this is the default integration if no bridge is supplied*)
 
@@ -31,24 +33,25 @@ To create top level methods, like for example <code>$.myUtility(...)</code>, you
 
 Another common case for Plugin developers is to be able hook into the internal collection chain. To do this, simply call the same <code>ender</code> method but pass <code>true</code> as the second argument:
 
-    !function ($) {
+    !function () {
+      var $ = require('ender');
       $.ender(myExtensions, true);
-    }(ender);
+    }();
 
 Within this scope the internal prototype is exposed to the developer with an existing <code>elements</code> instance property representing the node collection. Have a look at how the [Bonzo DOM utility](https://github.com/ded/bonzo/blob/master/src/ender.js) does this. Also note that the internal chain can be augmented at any time (outside of this build) during your application. For example:
 
     <script src="ender.js"></script>
     <script>
     // an example of creating a utility that returns a random element from the matched set
-    !function ($) {
-
+    !function () {
+      var $ = require('ender');
       $.ender({
         rand: function () {
           return this[Math.floor(Math.random() * (this.length))];
         }
       }, true);
 
-    }(ender);
+    }();
     $('p').rand();
     </script>
 


### PR DESCRIPTION
functionally equivalent, but more appropriate in that it doesn't use the global ender.
