### PR TITLE
use __proto__ in place of aug() where available

### DIFF
--- a/ender.js
+++ b/ender.js
@@ -17,6 +17,7 @@
 
   var modules = {}
     , old = context.$
+    , enderfy
 
   function require (identifier) {
     // modules can be required from ender's build system, or found on the window
@@ -38,12 +39,27 @@
   }
 
   function boosh(s, r, els) {
-    // string || node || nodelist || window
-    if (typeof s == 'string' || s.nodeName || (s.length && 'item' in s) || s == window) {
+    if (typeof s == 'undefined') {
+      els = []
+    } else if (typeof s == 'string' || s.nodeName || (s.length && 'item' in s) || s == window) {
+      // string || node || nodelist || window
       els = ender._select(s, r)
       els.selector = s
-    } else els = isFinite(s.length) ? s : [s]
-    return aug(els, boosh)
+    } else
+      els = isFinite(s.length) ? s : [s]
+    return enderfy(els)
+  }
+
+  if (({}).__proto__) {
+    boosh.__proto__ = Array.prototype
+    enderfy = function (o) {
+      o.__proto__ = boosh
+      return o
+    }
+  } else {
+    enderfy = function (o) {
+      return aug(o, boosh)
+    }
   }
 
   function ender(s, r) {


### PR DESCRIPTION
And now for something completely awesome...

Instead of doing a full property copy to element lists each time a call to `$()` is made, use `__proto__` to copy the whole prototype across in one go; leads to a **massive** speedup in browsers that support it (everything but IE).

`boosh` first needs to have `Array.prototype` attached to it so the returns still do everything arrays do, then you put `boosh` as the prototype of `els` (whatever it is!) and we get everything that's on `boosh` on `els`. So this works even if a property has been added via `$.fn`.

Here's the numbers: using just the Jeesh, doing a `$(element)` we get:
- 740% faster in Firefox (Aurora, Linux)
- 3,800% faster in Chrome (Beta, Linux)
- 2,150% faster in Opera (Windows)
- 1,200% faster in Safari (Windows)

And that's **just the Jeesh**! For every package you add you have more properties to copy with `aug()` and I bet most Ender builds have more than just the Jeesh.

Benchmarks can be run here in whatever browser you like: http://rvagg.github.com/ender-js/benchmarks/index.html (2 frames, top one has a standard Ender build, the bottom has the modified version using `__proto__`).

I'm using this in production on a large project of mine (with Jeesh + a ton of other packages) without any problems.
