### PR TITLE
ender.prototype = ender.fn = Ender.prototype

### DIFF
--- a/ender.js
+++ b/ender.js
@@ -85,19 +85,16 @@
   }
 
   ender['_VERSION'] = '0.4.3-dev'
-
-  ender.fn = Ender.prototype // for easy compat to jQuery plugins
+  
+  ender.prototype = ender.fn = Ender.prototype // for easy compat to jQuery plugins
 
   ender.ender = function (o, chain) {
     aug(chain ? Ender.prototype : ender, o)
   }
 
   ender._select = function (s, r) {
-    if (typeof s == 'string') return (r || document).querySelectorAll(s)
-    if (s.nodeName) return [s]
-    return s
+    return !s ? [] : s.nodeName ? [s] : (r || document).querySelectorAll(s)  
   }
-
 
   // use callback to receive Ender's require & provide
   ender.noConflict = function (callback) {


### PR DESCRIPTION
**ender.prototype** - Set `ender.prototype` to these so that `$('a') instanceof ender` will be `true` and so that if you add to the fn object like `ender.fn.example = 47` then it will map to the prototype and make `ender.fn.example === ender.prototype.example` be `true`.

**_select** - Make it so the default `_select` function can handle `$('')` and other falsey inputs without throwing a DOM exception 12 error.
