### PR TITLE
Fortify logic per #19 and amend comments

### DIFF
--- a/ender.js
+++ b/ender.js
@@ -100,10 +100,10 @@
   // Sync the prototypes for jQuery compatibility
   ender['fn'] = ender.prototype = Ender.prototype 
 
-  Ender.prototype.$ = ender // handy reference to self
+  Ender.prototype['$'] = ender // handy reference to self
 
   // dev tools secret sauce
-  Ender.prototype.splice = function () { throw new Error('Not implemented') }
+  Ender.prototype['splice'] = function () { throw new Error('Not implemented') }
   
   /**
    * @param   {function(*, number, Ender)} fn
@@ -158,7 +158,7 @@
     return this
   }
 
-  if (typeof module !== 'undefined' && module.exports) module.exports = ender
+  if (typeof module !== 'undefined' && module['exports']) module['exports'] = ender
   // use subscript notation as extern for Closure compilation
   // developers.google.com/closure/compiler/docs/api-tutorial3
   context['ender'] = context['$'] = ender


### PR DESCRIPTION
See #19. Fixes #17 too. I amended the [closure comments](https://developers.google.com/closure/compiler/docs/js-for-compiler) and made it all safe to compile in advanced mode. Itemized changes are in my [solid branch](https://github.com/ryanve/ender-js/commits/solid). I left an .x in the version number b/c I didn't know if I should bump it.
