### PR TITLE
Merge .fn as discussed in #23

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "ender-js"
-  , "version": "0.5.0"
+  , "version": "1.0.2"
   , "homepage": "https://github.com/ender-js/ender-js"
   , "description": "CommonJS like Module system, ender glue"
   , "main": "ender.js"

--- a/ender.js
+++ b/ender.js
@@ -92,7 +92,8 @@ Ender.prototype.forEach = function (fn, scope) {
  */
 ender.ender = function (o, chain) {
   var o2 = chain ? Ender.prototype : ender
-  for (var k in o) !(k in ender._reserved) && (o2[k] = o[k])
+  for (var k in o) k in ender._reserved || (o2[k] = o[k])
+  if (!chain && o.fn) ender.ender(o.fn, true)
   return o2
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ender-core"
   , "description": "core client library of Ender"
-  , "version": "1.0.1"
+  , "version": "1.0.2"
   , "keywords": ["ender", "modules", "library", "framework", "packager"]
   , "main": "./ender.js"
   , "ender": {


### PR DESCRIPTION
This change (discussed in #23) allows `ender.ender(object)` to safely merge incoming `.fn` objects like:

``` js
ender.ender({
  example: function() {},
  fn: {
    example: function() {}
  }
})
```
